### PR TITLE
Feature: 엔티티 필드 추가, @Column 어노테이션 추가

### DIFF
--- a/src/main/java/com/refactoringhabit/cart/domain/entity/Cart.java
+++ b/src/main/java/com/refactoringhabit/cart/domain/entity/Cart.java
@@ -19,6 +19,9 @@ public class Cart extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String altId; // 대체키
+
     private int quantity;
 
     @OneToOne

--- a/src/main/java/com/refactoringhabit/cart/domain/entity/Cart.java
+++ b/src/main/java/com/refactoringhabit/cart/domain/entity/Cart.java
@@ -3,6 +3,7 @@ package com.refactoringhabit.cart.domain.entity;
 import com.refactoringhabit.common.domain.entity.BaseTimeEntity;
 import com.refactoringhabit.member.domain.entity.Member;
 import com.refactoringhabit.product.domain.entity.Option;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,10 +19,13 @@ public class Cart extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
+    @Column(name = "alt_id")
     private String altId; // 대체키
 
+    @Column(name = "quantity")
     private int quantity;
 
     @OneToOne

--- a/src/main/java/com/refactoringhabit/category/domain/entity/Category.java
+++ b/src/main/java/com/refactoringhabit/category/domain/entity/Category.java
@@ -1,6 +1,7 @@
 package com.refactoringhabit.category.domain.entity;
 
 import com.refactoringhabit.common.domain.entity.BaseCreateTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,8 +14,15 @@ public class Category extends BaseCreateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "large")
     private String large;
+
+    @Column(name = "middle")
     private String middle;
 }

--- a/src/main/java/com/refactoringhabit/category/domain/entity/Category.java
+++ b/src/main/java/com/refactoringhabit/category/domain/entity/Category.java
@@ -14,6 +14,7 @@ public class Category extends BaseCreateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
     private String large;
     private String middle;
 }

--- a/src/main/java/com/refactoringhabit/host/domain/entity/Host.java
+++ b/src/main/java/com/refactoringhabit/host/domain/entity/Host.java
@@ -2,6 +2,7 @@ package com.refactoringhabit.host.domain.entity;
 
 import com.refactoringhabit.common.domain.entity.BaseTimeEntity;
 import com.refactoringhabit.member.domain.entity.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,15 +17,34 @@ public class Host extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "nick_name")
     private String nickName;
+
+    @Column(name = "phone")
     private String phone;
+
+    @Column(name = "profile_image")
     private String profileImage;
+
+    @Column(name = "email")
     private String email;
+
+    @Column(name = "introduction")
     private String introduction; // 호스트 소개글
+
+    @Column(name = "accountNumber")
     private String accountNumber; // 정산 계좌 번호
+
+    @Column(name = "bank")
     private String bank; // 정산 은행 이름
+
+    @Column(name = "account_holder")
     private String accountHolder; // 예금주
 
     @ManyToOne

--- a/src/main/java/com/refactoringhabit/host/domain/entity/Host.java
+++ b/src/main/java/com/refactoringhabit/host/domain/entity/Host.java
@@ -38,7 +38,7 @@ public class Host extends BaseTimeEntity {
     @Column(name = "introduction")
     private String introduction; // 호스트 소개글
 
-    @Column(name = "accountNumber")
+    @Column(name = "account_number")
     private String accountNumber; // 정산 계좌 번호
 
     @Column(name = "bank")

--- a/src/main/java/com/refactoringhabit/host/domain/entity/Host.java
+++ b/src/main/java/com/refactoringhabit/host/domain/entity/Host.java
@@ -17,6 +17,7 @@ public class Host extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
     private String nickName;
     private String phone;
     private String profileImage;

--- a/src/main/java/com/refactoringhabit/invoice/domain/entity/Invoice.java
+++ b/src/main/java/com/refactoringhabit/invoice/domain/entity/Invoice.java
@@ -3,6 +3,7 @@ package com.refactoringhabit.invoice.domain.entity;
 import com.refactoringhabit.common.domain.entity.BaseTimeEntity;
 import com.refactoringhabit.host.domain.entity.Host;
 import com.refactoringhabit.invoice.domain.enums.InvoiceStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -20,16 +21,32 @@ public class Invoice extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "period")
     private String period; // 정산 기간
+
+    @Column(name = "title")
     private String title; // 정산서 제목
+
+    @Column(name = "payment_amount")
     private int paymentAmount; // 지급액
+
+    @Column(name = "account_number")
     private String accountNumber; // 정산 계좌 번호
+
+    @Column(name = "account_holder")
     private  String accountHolder; // 예금주
+
+    @Column(name = "bank")
     private String bank; // 정산 은행 이름
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "status")
     private InvoiceStatus status; // 정산 지급 상태 - 'WAIT', 'COMPLETE'
 
     @ManyToOne

--- a/src/main/java/com/refactoringhabit/invoice/domain/entity/Invoice.java
+++ b/src/main/java/com/refactoringhabit/invoice/domain/entity/Invoice.java
@@ -21,6 +21,7 @@ public class Invoice extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
     private String period; // 정산 기간
     private String title; // 정산서 제목
     private int paymentAmount; // 지급액

--- a/src/main/java/com/refactoringhabit/invoice/domain/entity/InvoiceDetail.java
+++ b/src/main/java/com/refactoringhabit/invoice/domain/entity/InvoiceDetail.java
@@ -2,6 +2,7 @@ package com.refactoringhabit.invoice.domain.entity;
 
 import com.refactoringhabit.common.domain.entity.BaseCreateTimeEntity;
 import com.refactoringhabit.product.domain.entity.Product;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,9 +17,16 @@ public class InvoiceDetail extends BaseCreateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "total_price")
     private int totalPrice;
+
+    @Column(name = "total_quantity")
     private int totalQuantity;
 
     @ManyToOne

--- a/src/main/java/com/refactoringhabit/invoice/domain/entity/InvoiceDetail.java
+++ b/src/main/java/com/refactoringhabit/invoice/domain/entity/InvoiceDetail.java
@@ -17,6 +17,7 @@ public class InvoiceDetail extends BaseCreateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
     private int totalPrice;
     private int totalQuantity;
 

--- a/src/main/java/com/refactoringhabit/member/domain/entity/Member.java
+++ b/src/main/java/com/refactoringhabit/member/domain/entity/Member.java
@@ -4,6 +4,7 @@ import com.refactoringhabit.common.domain.entity.BaseTimeEntity;
 import com.refactoringhabit.member.domain.enums.Gender;
 import com.refactoringhabit.member.domain.enums.MemberStatus;
 import com.refactoringhabit.member.domain.enums.MemberType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -26,22 +27,40 @@ public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "email")
     private String email;
+
+    @Column(name = "password")
     private String password;
+
+    @Column(name = "nick_name")
     private String nickName;
+
+    @Column(name = "phone")
     private String phone;
+
+    @Column(name = "birth")
     private String birth;
+
+    @Column(name = "profile_image")
     private String profileImage;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
     private Gender gender;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "status")
     private MemberStatus status; // default 'ACTIVE'
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "type")
     private MemberType type; // default 'MEMBER'
 
     @Builder

--- a/src/main/java/com/refactoringhabit/member/domain/entity/Member.java
+++ b/src/main/java/com/refactoringhabit/member/domain/entity/Member.java
@@ -27,7 +27,7 @@ public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String mid; // 외부 이용 식별자 (UUID)
+    private String altId; // 대체키
     private String email;
     private String password;
     private String nickName;
@@ -45,10 +45,10 @@ public class Member extends BaseTimeEntity {
     private MemberType type; // default 'MEMBER'
 
     @Builder
-    public Member(String mid, String email, String password, String nickName, String phone,
+    public Member(String altId, String email, String password, String nickName, String phone,
         String birth, String profileImage, Gender gender) {
 
-        this.mid = mid;
+        this.altId = altId;
         this.email = email;
         this.password = password;
         this.nickName = nickName;

--- a/src/main/java/com/refactoringhabit/order/domain/entity/Order.java
+++ b/src/main/java/com/refactoringhabit/order/domain/entity/Order.java
@@ -25,7 +25,7 @@ public class Order extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String oid; // 외부 이용 식별자
+    private String altId; // 대체키
     private int price;
     private int quantity;
     private String usedAt;

--- a/src/main/java/com/refactoringhabit/order/domain/entity/Order.java
+++ b/src/main/java/com/refactoringhabit/order/domain/entity/Order.java
@@ -8,6 +8,7 @@ import com.refactoringhabit.order.domain.enums.PayMethod;
 import com.refactoringhabit.order.domain.enums.RefundStatus;
 import com.refactoringhabit.order.domain.enums.UsedStatus;
 import com.refactoringhabit.product.domain.entity.Option;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -25,19 +26,30 @@ public class Order extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "price")
     private int price;
+
+    @Column(name = "quantity")
     private int quantity;
+
+    @Column(name = "used_at")
     private String usedAt;
 
     @Enumerated(EnumType.STRING)
-    private PayMethod paymentMethod; // 'CARD'
+    @Column(name = "payment_method")
+    private PayMethod paymentMethod;
 
     @Enumerated(EnumType.STRING)
-    private RefundStatus refundStatus; // 'POSSIBLE', 'IMPOSSIBLE'
+    @Column(name = "refund_status")
+    private RefundStatus refundStatus; // default 'POSSIBLE'
 
     @Enumerated(EnumType.STRING)
-    private UsedStatus usedStatus; // 'UNUSED', 'USED', 'CANCELED'
+    @Column(name = "used_status")
+    private UsedStatus usedStatus; // default 'UNUSED'
 
     @ManyToOne
     @JoinColumn(name = "host_id")

--- a/src/main/java/com/refactoringhabit/product/domain/entity/Option.java
+++ b/src/main/java/com/refactoringhabit/product/domain/entity/Option.java
@@ -1,6 +1,7 @@
 package com.refactoringhabit.product.domain.entity;
 
 import com.refactoringhabit.product.domain.enums.OptionStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,14 +18,24 @@ public class Option {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "name")
     private String name;
+
+    @Column(name = "quantity")
     private int quantity;
+
+    @Column(name = "price")
     private int price;
 
     @Enumerated(EnumType.STRING)
-    private OptionStatus status; // 'SALE', 'SOLD_OUT'
+    @Column(name = "status")
+    private OptionStatus status; // default 'SALE'
 
     @ManyToOne
     @JoinColumn(name = "product_id")

--- a/src/main/java/com/refactoringhabit/product/domain/entity/Option.java
+++ b/src/main/java/com/refactoringhabit/product/domain/entity/Option.java
@@ -18,6 +18,7 @@ public class Option {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
     private String name;
     private int quantity;
     private int price;

--- a/src/main/java/com/refactoringhabit/product/domain/entity/Product.java
+++ b/src/main/java/com/refactoringhabit/product/domain/entity/Product.java
@@ -22,7 +22,7 @@ public class Product extends BaseCreateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String pid; // 외부 이용 식별자
+    private String altId; // 대체키
     private String name;
     private String zip_code;
     private String address1;

--- a/src/main/java/com/refactoringhabit/product/domain/entity/Product.java
+++ b/src/main/java/com/refactoringhabit/product/domain/entity/Product.java
@@ -5,6 +5,7 @@ import com.refactoringhabit.common.domain.entity.BaseCreateTimeEntity;
 import com.refactoringhabit.member.domain.entity.Member;
 import com.refactoringhabit.product.domain.enums.ProductStatus;
 import com.refactoringhabit.product.domain.enums.ProductType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -21,26 +22,42 @@ public class Product extends BaseCreateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+    @Column(name = "alt_id")
     private String altId; // 대체키
+    @Column(name = "name")
     private String name;
-    private String zip_code;
+    @Column(name = "zip_code")
+    private String zipCode;
+    @Column(name = "address1")
     private String address1;
+    @Column(name = "address2")
     private String address2;
-    private String extra_address;
+    @Column(name = "extra_address")
+    private String extraAddress;
+    @Column(name = "image")
     private String image;
+    @Column(name = "description")
     private String description;
+    @Column(name = "view")
     private Long view;
-    private String closed_at;
-    private String tag_gender;
-    private String tag_age;
-    private String tag_with;
+    @Column(name = "closed_at")
+    private String closedAt;
+    @Column(name = "tag_gender")
+    private String tagGender;
+    @Column(name = "tag_age")
+    private String tagAge;
+    @Column(name = "tag_with")
+    private String tagWith;
 
     @Enumerated(EnumType.STRING)
-    private ProductType type; // 'RESERVATION', 'TICKET'
+    @Column(name = "type")
+    private ProductType type;
 
     @Enumerated(EnumType.STRING)
-    private ProductStatus status; // 'OPENED', 'CLOSED'
+    @Column(name = "status")
+    private ProductStatus status; // default 'OPENED'
 
     @ManyToOne
     @JoinColumn(name = "category_id")

--- a/src/main/java/com/refactoringhabit/review/domain/entity/Review.java
+++ b/src/main/java/com/refactoringhabit/review/domain/entity/Review.java
@@ -4,6 +4,7 @@ import com.refactoringhabit.common.domain.entity.BaseTimeEntity;
 import com.refactoringhabit.member.domain.entity.Member;
 import com.refactoringhabit.product.domain.entity.Option;
 import com.refactoringhabit.review.domain.enums.ReviewStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -20,14 +21,24 @@ public class Review extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
+
+    @Column(name = "content")
     private String content;
+
+    @Column(name = "star_score")
     private int starScore;
+
+    @Column(name = "image")
     private String image;
 
     @Enumerated(EnumType.STRING)
-    private ReviewStatus status; // 리뷰 삭제시 상태만 변경 - 'SHOW', 'HIDE'
+    @Column(name = "status")
+    private ReviewStatus status; // default 'SHOW'
 
     @ManyToOne
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/refactoringhabit/review/domain/entity/Review.java
+++ b/src/main/java/com/refactoringhabit/review/domain/entity/Review.java
@@ -21,6 +21,7 @@ public class Review extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
     private String content;
     private int starScore;
     private String image;

--- a/src/main/java/com/refactoringhabit/wish/domain/entity/Wish.java
+++ b/src/main/java/com/refactoringhabit/wish/domain/entity/Wish.java
@@ -18,6 +18,7 @@ public class Wish extends BaseCreateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String altId; // 대체키
 
     @ManyToOne
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/refactoringhabit/wish/domain/entity/Wish.java
+++ b/src/main/java/com/refactoringhabit/wish/domain/entity/Wish.java
@@ -3,6 +3,7 @@ package com.refactoringhabit.wish.domain.entity;
 import com.refactoringhabit.common.domain.entity.BaseCreateTimeEntity;
 import com.refactoringhabit.member.domain.entity.Member;
 import com.refactoringhabit.product.domain.entity.Product;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,7 +18,10 @@ public class Wish extends BaseCreateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "alt_id")
     private String altId; // 대체키
 
     @ManyToOne


### PR DESCRIPTION
## 💻 작업 내용
- 엔티티 클래스 대체키(Alternate key) 컬럼 추가
  -  외부에서 pk 사용시, 자연키 대신 대체키 사용을 위해 컬럼 추가(UUID)
  - 참고 : [자연키(Natural key)와 대체키(Surrogate Key), PK(기본키)를 대체키로 설정해야 하는 이유](https://mangkyu.tistory.com/287)

- 엔티티 클래스 필드에 @Column 어노테이션 추가
  - 데이터베이스 이식성을 높이기 위해 @Column 어노테이션의 name 속성을 이용하여 컬럼명 명시