### PR TITLE
Feature: 임시 비밀번호 발급 API 생성, test 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 
     // Bouncy Castle Provider
     implementation 'org.bouncycastle:bcprov-jdk18on:1.76'
+
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    // Thymeleaf Layout Dialect(for email service)
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/refactoringhabit/auth/controller/AuthRestController.java
+++ b/src/main/java/com/refactoringhabit/auth/controller/AuthRestController.java
@@ -4,11 +4,13 @@ import com.refactoringhabit.auth.domain.service.AuthService;
 import com.refactoringhabit.auth.dto.FindEmailRequestDto;
 import com.refactoringhabit.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/auth")
@@ -19,5 +21,12 @@ public class AuthRestController {
     @PostMapping("/find-email")
     public ApiResponse<String> findEmail(@RequestBody FindEmailRequestDto findEmailRequestDto) {
         return ApiResponse.ok(authService.findEmail(findEmailRequestDto));
+    }
+
+    @PostMapping("/reset-password")
+    public ApiResponse<String> resetPassword(@RequestBody String email) {
+        log.debug("request data email : {}", email);
+        authService.resetPassword(email);
+        return ApiResponse.noContent();
     }
 }

--- a/src/main/java/com/refactoringhabit/auth/domain/exception/EmailingException.java
+++ b/src/main/java/com/refactoringhabit/auth/domain/exception/EmailingException.java
@@ -1,0 +1,7 @@
+package com.refactoringhabit.auth.domain.exception;
+
+import com.refactoringhabit.common.exception.CustomException;
+
+public class EmailingException extends CustomException {
+
+}

--- a/src/main/java/com/refactoringhabit/auth/domain/service/AuthService.java
+++ b/src/main/java/com/refactoringhabit/auth/domain/service/AuthService.java
@@ -1,21 +1,86 @@
 package com.refactoringhabit.auth.domain.service;
 
+import com.refactoringhabit.auth.domain.exception.EmailingException;
 import com.refactoringhabit.auth.dto.FindEmailRequestDto;
+import com.refactoringhabit.member.domain.entity.Member;
 import com.refactoringhabit.member.domain.exception.NotFoundEmailException;
 import com.refactoringhabit.member.domain.repository.MemberRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final MemberRepository memberRepository;
-    
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine springTemplateEngine;
+    private final PasswordEncoder passwordEncoder;
+
+    private final Random random = new Random();
+    private static final String EMAIL_SUBJECT = "[habit] 임시 비밀번호 발급";
+    private static final String EMAIL_TEMPLATE_NAME = "/pages/reset-password";
+
     @Transactional(readOnly = true)
     public String findEmail(FindEmailRequestDto findEmailRequestDto) {
         return memberRepository.findEmailByPhoneAndBirth(findEmailRequestDto)
             .orElseThrow(NotFoundEmailException::new);
+    }
+
+    @Transactional
+    public void resetPassword(String email) {
+        String newPassword = createPassword();
+        Member member = memberRepository.findByEmail(email);
+        member.updatePassword(passwordEncoder.encode(newPassword));
+
+        try {
+            sendEmail(email, newPassword);
+        } catch (MessagingException e) {
+            log.error("[{}] {}", e.getClass().getSimpleName(), e.getMessage());
+            throw new EmailingException();
+        }
+    }
+
+    private String createPassword() {
+        StringBuilder newPassword = new StringBuilder();
+        boolean run = true;
+        while (run) {
+            int num = random.nextInt(122);
+            if ((num >= 48 && num <= 57) || (num >= 65 && num <= 90) || (num >= 97)) {
+                newPassword.append((char) num);
+            }
+            if (newPassword.length() == 10) {
+                run = false;
+            }
+        }
+        return newPassword.toString();
+    }
+
+    private String setContext(String newPassword) {
+        Context context = new Context();
+        context.setVariable("newPassword", newPassword);
+        return springTemplateEngine.process(EMAIL_TEMPLATE_NAME, context);
+    }
+
+    private void sendEmail(String email, String newPassword) throws MessagingException {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper
+            = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+        mimeMessageHelper.setTo(email);
+        mimeMessageHelper.setSubject(EMAIL_SUBJECT);
+        mimeMessageHelper.setText(setContext(newPassword), true);
+        javaMailSender.send(mimeMessage);
     }
 }

--- a/src/main/java/com/refactoringhabit/auth/domain/service/AuthService.java
+++ b/src/main/java/com/refactoringhabit/auth/domain/service/AuthService.java
@@ -10,6 +10,7 @@ import jakarta.mail.internet.MimeMessage;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -46,7 +47,7 @@ public class AuthService {
 
         try {
             sendEmail(email, newPassword);
-        } catch (MessagingException e) {
+        } catch (MessagingException | MailException e) {
             log.error("[{}] {}", e.getClass().getSimpleName(), e.getMessage());
             throw new EmailingException();
         }
@@ -73,7 +74,9 @@ public class AuthService {
         return springTemplateEngine.process(EMAIL_TEMPLATE_NAME, context);
     }
 
-    private void sendEmail(String email, String newPassword) throws MessagingException {
+    private void sendEmail(String email, String newPassword)
+        throws MessagingException, MailException {
+
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         MimeMessageHelper mimeMessageHelper
             = new MimeMessageHelper(mimeMessage, false, "UTF-8");

--- a/src/main/java/com/refactoringhabit/common/config/mail/MailConfig.java
+++ b/src/main/java/com/refactoringhabit/common/config/mail/MailConfig.java
@@ -1,0 +1,65 @@
+package com.refactoringhabit.common.config.mail;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    private static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
+    private static final String MAIL_DEBUG = "mail.smtp.debug";
+    private static final String MAIL_CONNECTION_TIMEOUT = "mail.smtp.connection-timeout";
+    private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+
+    // SMTP 서버
+    @Value("${spring.mail.host}")
+    private String host;
+
+    // 계정
+    @Value("${spring.mail.username}")
+    private String username;
+
+    // 비밀번호
+    @Value("${spring.mail.password}")
+    private String password;
+
+    // 포트번호
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.debug}")
+    private boolean debug;
+
+    @Value("${spring.mail.properties.mail.smtp.connection-timeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.starttls.enable}")
+    private boolean startTlsEnable;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+
+        Properties properties = javaMailSender.getJavaMailProperties();
+        properties.put(MAIL_SMTP_AUTH, auth);
+        properties.put(MAIL_DEBUG, debug);
+        properties.put(MAIL_CONNECTION_TIMEOUT, connectionTimeout);
+        properties.put(MAIL_SMTP_STARTTLS_ENABLE, startTlsEnable);
+
+        javaMailSender.setJavaMailProperties(properties);
+        javaMailSender.setDefaultEncoding("UTF-8");
+
+        return javaMailSender;
+    }
+}

--- a/src/main/java/com/refactoringhabit/common/exception/ErrorType.java
+++ b/src/main/java/com/refactoringhabit/common/exception/ErrorType.java
@@ -1,5 +1,6 @@
 package com.refactoringhabit.common.exception;
 
+import com.refactoringhabit.auth.domain.exception.EmailingException;
 import com.refactoringhabit.member.domain.exception.FileSaveFailedException;
 import com.refactoringhabit.member.domain.exception.NotFoundEmailException;
 import java.util.Arrays;
@@ -17,7 +18,9 @@ public enum ErrorType {
     F001("F001", "파일 저장에 실패했습니다.",
         FileSaveFailedException.class, HttpStatus.INTERNAL_SERVER_ERROR),
     U001("U001", "이메일을 찾을 수 없습니다.",
-        NotFoundEmailException.class, HttpStatus.NOT_FOUND);
+        NotFoundEmailException.class, HttpStatus.NOT_FOUND),
+    A001("A001", "이메일 발송에 실패하였습니다.",
+        EmailingException.class, HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/refactoringhabit/member/domain/entity/Member.java
+++ b/src/main/java/com/refactoringhabit/member/domain/entity/Member.java
@@ -76,4 +76,8 @@ public class Member extends BaseTimeEntity {
         this.profileImage = profileImage;
         this.gender = gender;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/refactoringhabit/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/refactoringhabit/member/domain/repository/MemberRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Boolean existsByEmail(String email);
+
+    Member findByEmail(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,17 @@ spring:
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
 
+  mail:
+    host: ${EMAIL_HOST}
+    port: ${EMAIL_PORT}
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail.smtp.debug: true
+      mail.smtp.connection-timeout: 1000 #1초
+      mail.starttls.enable: true
+      mail.smtp.auth: true
+
 file:
   storage-path: ${STORAGE_PATH}
   member-default-img: "member_default_img.png"

--- a/src/main/resources/static/css/member/find-password.css
+++ b/src/main/resources/static/css/member/find-password.css
@@ -39,3 +39,25 @@
   color: white;
   margin-bottom: 50px;
 }
+
+#div_load_img {
+  display: none;
+  justify-content: center;
+  position: fixed;
+  top: 103px;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(171, 171, 171, 0.3)
+}
+
+#load_img_container {
+  position: absolute;
+  top: 30%;
+  height: 0;
+  z-index: 9999;
+  background: rgba(126, 125, 125, 0.54);
+  filter: alpha(opacity=50);
+  margin: auto;
+  padding: 0
+}
+

--- a/src/main/resources/static/js/member/find-password.js
+++ b/src/main/resources/static/js/member/find-password.js
@@ -1,42 +1,50 @@
-$(document).ready(()=>{
-  window.onload=function(){
-       //common.js
-       common();
+$(document).ready(()=> {
+  let responseData = sessionStorage.getItem('responseData')
+  if (responseData === null) {
+    alert('핸드폰번호, 생년월일을 먼저 인증해주세요.')
+    window.location.href = '/find-member'
+
+  } else {
+    let email = JSON.parse(responseData).data
+    let showEmail = ''
+
+    for (let i = 0; i < email.length; i++) {
+      if (i < 4 || email[i] === '@' || (i >= 4 && email[i] === '\.')) {
+        showEmail += email[i]
+      } else {
+        showEmail += '*'
+      }
+    }
+
+    $('#found_email').text(showEmail)
   }
 
   $('#sendEmail').on('click', ()=>{
 
-       if (confirm("임시 비밀번호를 발급받으시겠습니까?")) {
-            let checkMethod = $('input[type=radio][name="method"]:checked')
-            let methodOfFine = checkMethod.attr("id")
-            let methodValue = checkMethod.val()
+    if (confirm("임시 비밀번호를 발급받으시겠습니까?")) {
+      let responseData = sessionStorage.getItem('responseData')
 
-            let requestData = {
-                 'methodOfFine': methodOfFine,
-                 'methodValue': methodValue
-            }
+      $.ajax({
+        url: '/api/v2/auth/reset-password',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.parse(responseData).data,
+        success: () => {
+          sessionStorage.removeItem('responseData')
+          $('#sendEmailContainer').attr('hidden', true)
+          $('#result').attr('hidden', false)
+        },
+        beforeSend: () => {
+          $('#div_load_img').css('display', 'flex')
+        },
+        complete: () => {
+          $('#div_load_img').css('display', 'none')
+        }
+      })
 
-            $.ajax({
-                 url: '/findpw/result',
-                 type: 'post',
-                 dataType: 'json',
-                 data: requestData,
-                 success: (result) => {
-                      if (result == 1) {
-                           $('#methodSelect').attr('hidden', true);
-                           $('#result').removeAttr('hidden')
-                      }
-                 },
-                 beforeSend: () => {
-                      $('#div_load_img').css('display', 'flex')
-                 },
-                 complete: () => {
-                      $('#div_load_img').css('display', 'none')
-                 }
-            })
-       } else {
-            return false
-       }
-
+    } else {
+      sessionStorage.removeItem('responseData')
+      return false
+    }
   })
 })

--- a/src/main/resources/templates/pages/member/find-password.html
+++ b/src/main/resources/templates/pages/member/find-password.html
@@ -10,8 +10,8 @@
 
   <section>
     <!-- 본문 시작 -->
-    <div id="div_load_img" style="display: none; justify-content: center; position: fixed; width: 100%; height: 100%; background-color: rgba(171,171,171,0.3)">
-      <div style="position: absolute; top: 30%; height: 0px; z-index: 9999; background: rgba(126,125,125,0.54); filter: alpha(opacity=50); opacity: alpha*0.5; margin: auto; padding: 0">
+    <div id="div_load_img">
+      <div id="load_img_container">
         <img src="/img/loading.gif" style="width: 70px; height: 70px;">
       </div>
     </div>
@@ -21,25 +21,19 @@
       </div>
       <hr>
       <div class="Home_form_wrapper">
-        <div id="methodSelect">
+        <div id="sendEmailContainer">
           <div class="Home_ment">
-            임시 비밀번호 발급 방법을 선택해주세요
+            회원 정보에 등록된 이메일
           </div>
           <div>
-            <div class="Home_select">
-              <input type="radio" name="method" id="user_email" checked>&nbsp;<label for="user_email">회원정보에 등록된 이메일로 받기
-              <span>abcd***@******.***</span></label>
-            </div>
-            <div class="Home_select">
-              <input type="radio" name="method" id="user_phone">&nbsp;<label for="user_phone">회원정보에 등록된 휴대전화번호로 받기 <span>010-****-1234</span></label>
-            </div>
-            <button class="Home_btn" id="sendEmail">임시비밀번호 전송</button>
+            <div class="Home_select" id="found_email"></div>
+            <button class="Home_btn" id="sendEmail">임시 비밀번호 발송</button>
           </div>
         </div>
         <!--전송 완료시-->
         <div id="result" hidden>
           <div>전송이 완료되었습니다. 임시 비밀번호를 확인해주세요.</div>
-          <button class="Home_btn" onclick="location.href='/login'">로그인 페이지로 돌아가기</button>
+          <button class="Home_btn" onclick="location.href='/login'">로그인 하기</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/pages/reset-password.html
+++ b/src/main/resources/templates/pages/reset-password.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+<div style="margin:0px; width:100%; background-color:#F2F0FF; padding:0px; padding-top:8px;">
+  <table
+      style="width: 512px; align-content: center; position: relative; overflow: hidden; background: #fff;
+        margin: 0px auto; max-width:512px; background-color:#ffffff; padding:0px">
+    <tr>
+      <td style="height: 49px;">
+        <img src="/img/habit_logo.png" style="width: 80px; vertical-align: middle;"/>
+        <p style="font-size: 20px; font-weight: 700; text-align: left; color: #140f33; display: inline-block; vertical-align: middle; margin-left: 10px;">임시 비밀번호 발급</p>
+      </td>
+    </tr>
+    <!--구분선-->
+    <tr>
+      <td colspan="2" style="background-color: lightgray; margin-bottom: 10px;"></td>
+    </tr>
+    <tr>
+      <td colspan="2" style="text-align: center;">
+        <p>임시 비밀번호 10자리는 아래와 같습니다</p>
+        <p><strong th:text="${newPassword}"></strong></p>
+        <p style="font-size: small; color: gray;">habit 로그인 후 비밀번호를 변경하시기 바랍니다</p>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2" style="background-color: lightgray; margin-bottom: 10px;"></td>
+    </tr>
+    <tr>
+      <td colspan="2" style="font-size: 14px; font-weight: 300; text-align: center; color: #686868; padding-top: 5px;">
+        © 2024 HABIT, All rights reserved
+      </td>
+    </tr>
+  </table>
+</div>
+</body>
+</html>

--- a/src/test/java/com/refactoringhabit/auth/domain/service/AuthServiceTest.java
+++ b/src/test/java/com/refactoringhabit/auth/domain/service/AuthServiceTest.java
@@ -1,0 +1,128 @@
+package com.refactoringhabit.auth.domain.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.refactoringhabit.auth.domain.exception.EmailingException;
+import com.refactoringhabit.auth.dto.FindEmailRequestDto;
+import com.refactoringhabit.member.domain.entity.Member;
+import com.refactoringhabit.member.domain.exception.NotFoundEmailException;
+import com.refactoringhabit.member.domain.repository.MemberRepository;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private static final String TEST_EMAIL_ADDRESS = "test@example.com";
+    private static final String ENCODED_PASSWORD = "encodedPassword";
+
+    @BeforeEach
+    void setUp() {
+        ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("/templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode("HTML5");
+        templateResolver.setCharacterEncoding("UTF-8");
+
+        SpringTemplateEngine springTemplateEngine = new SpringTemplateEngine();
+        springTemplateEngine.setTemplateResolver(templateResolver);
+
+        authService = new AuthService(memberRepository, javaMailSender, springTemplateEngine,
+            passwordEncoder);
+    }
+
+    @DisplayName("이메일찾기 - 성공")
+    @Test
+    void testFindEmail_Successfully() {
+        FindEmailRequestDto findEmailRequestDto = new FindEmailRequestDto();
+        when(memberRepository.findEmailByPhoneAndBirth(findEmailRequestDto))
+            .thenReturn(Optional.of(TEST_EMAIL_ADDRESS));
+
+        String email = authService.findEmail(findEmailRequestDto);
+
+        assertEquals(TEST_EMAIL_ADDRESS, email);
+        verify(memberRepository, times(1))
+            .findEmailByPhoneAndBirth(findEmailRequestDto);
+    }
+
+    @DisplayName("이메일찾기 - 실패 : 찾을 수 없는 이메일 예외 발생")
+    @Test
+    void testFindEmail_NotFound() {
+        FindEmailRequestDto findEmailRequestDto = new FindEmailRequestDto();
+        when(memberRepository.findEmailByPhoneAndBirth(findEmailRequestDto))
+            .thenReturn(Optional.empty());
+
+        assertThrows(NotFoundEmailException.class, () -> {
+            authService.findEmail(findEmailRequestDto);
+        });
+    }
+
+    @DisplayName("임시 비밀번호 발급 - 성공")
+    @Test
+    void testResetPassword_Successfully() {
+        String email = TEST_EMAIL_ADDRESS;
+        Member member = mock(Member.class);
+        when(memberRepository.findByEmail(email)).thenReturn(member);
+        when(passwordEncoder.encode(anyString())).thenReturn(ENCODED_PASSWORD);
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        authService.resetPassword(email);
+
+        verify(member, times(1)).updatePassword(anyString());
+        verify(javaMailSender, times(1)).send(mimeMessage);
+    }
+
+    @DisplayName("임시 비밀번호 발급 - 실패 : 이메일 발송 실패")
+    @Test
+    void testResetPassword_EmailException() {
+        String email = TEST_EMAIL_ADDRESS;
+        Member member = mock(Member.class);
+        when(memberRepository.findByEmail(email)).thenReturn(member);
+        when(passwordEncoder.encode(anyString())).thenReturn(ENCODED_PASSWORD);
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        doThrow(MailSendException.class).when(javaMailSender).send(mimeMessage);
+
+        assertThrows(EmailingException.class, () -> {
+            authService.resetPassword(email);
+        });
+
+        verify(member, times(1)).updatePassword(anyString());
+        verify(javaMailSender, times(1)).send(mimeMessage);
+    }
+}


### PR DESCRIPTION
## 💻 작업 내용
1. 회원 인증(입력받은 휴대폰번호, 생년월일로 이메일 찾기) 후 임시 비밀번호 발급 버튼 클릭
2. 랜덤 비밀번호 10자리 생성 후 해당 계정의 비밀번호 변경
3. 비밀번호 변경 완료시 임시 비밀번호를 해당 계정(이메일)으로 발송
![image](https://github.com/newnyee/refactoring-habit/assets/121937711/82a6b2c4-de2e-461e-9c23-6b6714c36a67)


- 아이디/비밀번호 찾기 서비스 코드의 test 코드 작성

## 🔎 PR 특이 사항
![image](https://github.com/newnyee/refactoring-habit/assets/121937711/c70152a4-fa48-4d26-b70f-7e7f3e50ec19)
- 4개의 단위 테스트 : 이메일 찾기(성공, 실패), 임시 비밀번호 발급(성공, 실패)
- Tests passed : 4