### PR TITLE
Refactor: 임시 비밀번호 이메일 전송 리팩토링

### DIFF
--- a/src/main/java/com/refactoringhabit/auth/controller/AuthRestController.java
+++ b/src/main/java/com/refactoringhabit/auth/controller/AuthRestController.java
@@ -25,7 +25,6 @@ public class AuthRestController {
 
     @PostMapping("/reset-password")
     public ApiResponse<String> resetPassword(@RequestBody String email) {
-        log.debug("request data email : {}", email);
         authService.resetPassword(email);
         return ApiResponse.noContent();
     }

--- a/src/main/java/com/refactoringhabit/auth/domain/service/AuthService.java
+++ b/src/main/java/com/refactoringhabit/auth/domain/service/AuthService.java
@@ -2,22 +2,19 @@ package com.refactoringhabit.auth.domain.service;
 
 import com.refactoringhabit.auth.domain.exception.EmailingException;
 import com.refactoringhabit.auth.dto.FindEmailRequestDto;
+import com.refactoringhabit.common.annotation.Timer;
+import com.refactoringhabit.common.utils.EmailNewPasswordUtil;
 import com.refactoringhabit.member.domain.entity.Member;
 import com.refactoringhabit.member.domain.exception.NotFoundEmailException;
 import com.refactoringhabit.member.domain.repository.MemberRepository;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.context.Context;
-import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Slf4j
 @Service
@@ -25,13 +22,10 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 public class AuthService {
 
     private final MemberRepository memberRepository;
-    private final JavaMailSender javaMailSender;
-    private final SpringTemplateEngine springTemplateEngine;
     private final PasswordEncoder passwordEncoder;
+    private final EmailNewPasswordUtil emailNewPasswordUtil;
 
     private final Random random = new Random();
-    private static final String EMAIL_SUBJECT = "[habit] 임시 비밀번호 발급";
-    private static final String EMAIL_TEMPLATE_NAME = "/pages/reset-password";
 
     @Transactional(readOnly = true)
     public String findEmail(FindEmailRequestDto findEmailRequestDto) {
@@ -39,6 +33,7 @@ public class AuthService {
             .orElseThrow(NotFoundEmailException::new);
     }
 
+    @Timer
     @Transactional
     public void resetPassword(String email) {
         String newPassword = createPassword();
@@ -46,7 +41,7 @@ public class AuthService {
         member.updatePassword(passwordEncoder.encode(newPassword));
 
         try {
-            sendEmail(email, newPassword);
+            emailNewPasswordUtil.sendEmail(email, newPassword);
         } catch (MessagingException | MailException e) {
             log.error("[{}] {}", e.getClass().getSimpleName(), e.getMessage());
             throw new EmailingException();
@@ -66,24 +61,5 @@ public class AuthService {
             }
         }
         return newPassword.toString();
-    }
-
-    private String setContext(String newPassword) {
-        Context context = new Context();
-        context.setVariable("newPassword", newPassword);
-        return springTemplateEngine.process(EMAIL_TEMPLATE_NAME, context);
-    }
-
-    private void sendEmail(String email, String newPassword)
-        throws MessagingException, MailException {
-
-        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        MimeMessageHelper mimeMessageHelper
-            = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-
-        mimeMessageHelper.setTo(email);
-        mimeMessageHelper.setSubject(EMAIL_SUBJECT);
-        mimeMessageHelper.setText(setContext(newPassword), true);
-        javaMailSender.send(mimeMessage);
     }
 }

--- a/src/main/java/com/refactoringhabit/common/annotation/Timer.java
+++ b/src/main/java/com/refactoringhabit/common/annotation/Timer.java
@@ -1,0 +1,10 @@
+package com.refactoringhabit.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Timer {}

--- a/src/main/java/com/refactoringhabit/common/config/async/AsyncConfig.java
+++ b/src/main/java/com/refactoringhabit/common/config/async/AsyncConfig.java
@@ -1,0 +1,37 @@
+package com.refactoringhabit.common.config.async;
+
+import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "emailAsyncExecutor")
+    public Executor getAsyncExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(12); // 서버의 물리적인 코어 수 * 2 (I/O-bound 작업)
+        executor.setMaxPoolSize(24);
+        executor.setQueueCapacity(100);
+        executor.setAwaitTerminationSeconds(60);
+        executor.setThreadNamePrefix("Asynchronous Mail Sender Thread-");
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+            log.error(
+                "Asynchronous method thrown exception... -> Method = {}, Params = {}",
+                method, params, ex
+            );
+    }
+}

--- a/src/main/java/com/refactoringhabit/common/config/mail/MailConfig.java
+++ b/src/main/java/com/refactoringhabit/common/config/mail/MailConfig.java
@@ -23,11 +23,9 @@ public class MailConfig {
     @Value("${spring.mail.username}")
     private String username;
 
-    // 비밀번호
     @Value("${spring.mail.password}")
     private String password;
 
-    // 포트번호
     @Value("${spring.mail.port}")
     private int port;
 

--- a/src/main/java/com/refactoringhabit/common/custom/TimerAop.java
+++ b/src/main/java/com/refactoringhabit/common/custom/TimerAop.java
@@ -1,0 +1,30 @@
+package com.refactoringhabit.common.custom;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Slf4j
+@Aspect
+@Component
+public class TimerAop {
+
+    @Pointcut("@annotation(com.refactoringhabit.common.annotation.Timer)")
+    private void enableTimer() {}
+
+    @Around("enableTimer()")
+    public void around(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        joinPoint.proceed();
+        stopWatch.stop();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        log.debug("{} - 실행시간 : {} ms", signature.getName(), stopWatch.getTotalTimeMillis());
+    }
+}

--- a/src/main/java/com/refactoringhabit/common/utils/EmailNewPasswordUtil.java
+++ b/src/main/java/com/refactoringhabit/common/utils/EmailNewPasswordUtil.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
@@ -28,6 +29,7 @@ public class EmailNewPasswordUtil {
     }
 
     @Timer
+    @Async
     public void sendEmail(String email, String newPassword)
         throws MessagingException, MailException {
 

--- a/src/main/java/com/refactoringhabit/common/utils/EmailNewPasswordUtil.java
+++ b/src/main/java/com/refactoringhabit/common/utils/EmailNewPasswordUtil.java
@@ -1,0 +1,43 @@
+package com.refactoringhabit.common.utils;
+
+import com.refactoringhabit.common.annotation.Timer;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Component
+@RequiredArgsConstructor
+public class EmailNewPasswordUtil {
+
+    private final SpringTemplateEngine springTemplateEngine;
+    private final JavaMailSender javaMailSender;
+
+    private static final String EMAIL_SUBJECT = "[habit] 임시 비밀번호 발급";
+    private static final String EMAIL_TEMPLATE_NAME = "/pages/reset-password";
+
+    private String setContext(String newPassword) {
+        Context context = new Context();
+        context.setVariable("newPassword", newPassword);
+        return springTemplateEngine.process(EMAIL_TEMPLATE_NAME, context);
+    }
+
+    @Timer
+    public void sendEmail(String email, String newPassword)
+        throws MessagingException, MailException {
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper
+            = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+        mimeMessageHelper.setTo(email);
+        mimeMessageHelper.setSubject(EMAIL_SUBJECT);
+        mimeMessageHelper.setText(setContext(newPassword), true);
+        javaMailSender.send(mimeMessage);
+    }
+}

--- a/src/main/resources/static/css/member/common.css
+++ b/src/main/resources/static/css/member/common.css
@@ -331,3 +331,9 @@ a:hover{
   color: red;
   font-size: small;
 }
+
+.warning-message {
+  margin: 30px 0 0;
+  color: gray;
+  font-size: small;
+}

--- a/src/main/resources/templates/pages/member/find-password.html
+++ b/src/main/resources/templates/pages/member/find-password.html
@@ -33,6 +33,7 @@
         <!--전송 완료시-->
         <div id="result" hidden>
           <div>전송이 완료되었습니다. 임시 비밀번호를 확인해주세요.</div>
+          <div class="warning-message">3분이 지나도 이메일이 오지 않으면 다시 요청해주세요.</div>
           <button class="Home_btn" onclick="location.href='/login'">로그인 하기</button>
         </div>
       </div>

--- a/src/main/resources/templates/pages/reset-password.html
+++ b/src/main/resources/templates/pages/reset-password.html
@@ -10,7 +10,7 @@
         margin: 0px auto; max-width:512px; background-color:#ffffff; padding:0px">
     <tr>
       <td style="height: 49px;">
-        <img src="/img/habit_logo.png" style="width: 80px; vertical-align: middle;"/>
+        <img src="https://github.com/newnyee/refactoring-habit/assets/121937711/84861673-dda3-4931-a592-0ae288439cbf" style="width: 80px; vertical-align: middle;"/>
         <p style="font-size: 20px; font-weight: 700; text-align: left; color: #140f33; display: inline-block; vertical-align: middle; margin-left: 10px;">임시 비밀번호 발급</p>
       </td>
     </tr>


### PR DESCRIPTION
## 🛠 리팩토링 목적
- 이메일 전송으로 인한 지연 시간(약 3초)을 줄이기 위한 리팩토링
- SMTP 프로토콜 사용으로 인한 TCP Connection 수립으로인한 지연은 제어할 수 없으나, 해당 부분을 실행하는 메소드(sendEmail())를 비동기 처리하여 서버의 실행시간을 줄임
<br>

## 💻 작업 내용
- 실행 시간 측정을 위한 @Timer 어노테이션 생성 4cea018322eb4d268150da38691473b2c4424388
![image](https://github.com/newnyee/refactoring-habit/assets/121937711/3e9e3800-302c-4bbf-bd73-84bc9256647f)

- @Async 어노테이션을 이용한 이메일 전송 메서드 비동기 처리 93ad37b91fada2b12ee6e24bf8a4e729cdab0b9e
- 메일 전송을 실패할 경우를 대비한 안내문구 추가 223e5c0902fa7c8c8b3988de4fa18fe221783b9b
  - 비동기 처리를 했으므로 예외처리가 불가(호출 스레드가 먼저 실행 완료 되어 클라이언트로 200 상태 보냄)하여 안내 문구 삽입함
<p align="center">
<img src="https://github.com/newnyee/refactoring-habit/assets/121937711/01e44da4-5f25-416c-b9aa-09be05823db4" width="500"/>
</p>

- 서비스 로직 변경으로 인한 test 코드 변경 6987bf3c19a42cd3617b36c3af1c8d5c4262d1eb
<br>

## 🔎 PR 특이 사항
- 비동기 처리 전 (실행시간 : 3745ms)
![image](https://github.com/newnyee/refactoring-habit/assets/121937711/b8fb0329-ec2b-444d-8335-9fad569c2fbe)
- 비동기 처리 후 (실행시간 : 199ms)
![image](https://github.com/newnyee/refactoring-habit/assets/121937711/58bdb188-9a5d-4eb2-b03f-35a2d8c602e5)

- test 코드 변경
  - 4개의 단위 테스트 : 이메일 찾기(성공, 실패), 임시 비밀번호 발급(성공, 실패)
  - Tests passed : 4
![image](https://github.com/newnyee/refactoring-habit/assets/121937711/84b5602f-7ed8-4219-b551-f085adb2346c)
